### PR TITLE
Packaging for v2.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.5
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler:1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_cli (1.0.3)
+    shopify_api_console (2.0.0)
       activemodel (>= 4.2.2)
       activesupport (>= 4.2.2)
       pry (>= 0.9.12.6)
@@ -11,8 +11,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.2)
-      activesupport (= 5.2.2)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
@@ -21,20 +21,20 @@ GEM
       activemodel (>= 5.0, < 7)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 5.0, < 7)
-    activesupport (5.2.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     builder (3.2.3)
     coderay (1.1.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.5)
     fakeweb (1.3.0)
-    graphql (1.8.11)
+    graphql (1.9.6)
     graphql-client (0.14.0)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
-    i18n (1.1.1)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
     method_source (0.9.2)
@@ -44,10 +44,10 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rake (10.4.2)
-    shopify_api (5.2.0)
-      activeresource (>= 3.0.0)
+    shopify_api (7.0.1)
+      activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
     thor (0.18.1)
@@ -63,7 +63,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   mocha (>= 0.9.8)
   rake
-  shopify_cli!
+  shopify_api_console!
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_cli (1.0.2)
+    shopify_cli (1.0.3)
       activemodel (>= 4.2.2)
       activesupport (>= 4.2.2)
       pry (>= 0.9.12.6)

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
-Copyright (c) 2015 "Shopify inc."
+Copyright (c) 2015 Shopify
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
+'Software'), to deal in the Software without restriction, including
 without limitation the rights to use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and to
 permit persons to whom the Software is furnished to do so, subject to
@@ -11,10 +11,10 @@ the following conditions:
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+[![Build Status](https://travis-ci.org/Shopify/shopify_api_console_ruby.svg?branch=master)](https://travis-ci.org/Shopify/shopify_api_console_ruby)
+
 # This gem has been renamed
 
 * Name: shopify_cli --> shopify_api_console
 * GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console_ruby
-* RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console_ruby
+* RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console
 
 shopify_cli 1.x will not be supported going forward. v1.0.3 will produce a deprecation warning.
 
@@ -13,3 +15,43 @@ Starting with v2.0, the gem has been renamed to `shopify_api_console`. We recomm
 ```
 gem install shopify_cli -v v1.0.3
 ```
+
+# Shopify API Console for Ruby
+
+This package includes the ``shopify-api`` executable to make it easy to open up an interactive console to use the Admin API with a shop.
+
+```sh
+gem install shopify_api_console
+```
+
+## Usage
+
+See the documentation at https://help.shopify.com/en/api/guides/using-the-api-console
+
+## Getting started
+
+1. Obtain a private API key and password to use with your shop (step 2 in "Getting Started")
+
+2. Use the ``shopify-api`` script to save the credentials for the shop to quickly log in.
+
+   ```bash
+   shopify-api add yourshopname
+   ```
+
+   Follow the prompts for the shop domain, API key and password.
+
+3. Start the console for the connection.
+
+   ```bash
+   shopify-api console
+   ```
+
+   ```bash
+   shopify-api help
+   ```
+
+## Contributing
+
+After checking out the source, run:
+
+  `$ bundle install && bundle exec rake test`

--- a/README.md
+++ b/README.md
@@ -1,66 +1,15 @@
-[![Build Status](https://travis-ci.org/Shopify/shopify_cli.svg?branch=master)](https://travis-ci.org/Shopify/shopify_cli)
+# This gem has been renamed
 
-This package includes the ``shopify-cli`` executable to make it easy to open up an interactive console to use the API with a shop.
+* Name: shopify_cli --> shopify_api_console
+* GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console_ruby
+* RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console_ruby
 
-# Installation
+shopify_cli 1.x will not be supported going forward. v1.0.3 will produce a deprecation warning.
 
-```sh
-gem install shopify_cli
+Starting with v2.0, the gem has been renamed to `shopify_api_console`. We recommend switching to shopify_api_console v2.0+ as soon as possible.
+
+1.x versions will continue to exist on [RubyGems](https://rubygems.org/gems/shopify_cli) and in the [GitHub releases](https://github.com/Shopify/shopify_cli/releases). If you _must_ use one of these releases, make sure to specify a version:
+
 ```
-
-# Usage
-
-See the documentation at https://help.shopify.com/en/api/guides/using-the-api-console
-
-# Getting started
-
-1. Obtain a private API key and password to use with your shop (step 2 in "Getting Started")
-
-2. Use the ``shopify-cli`` script to save the credentials for the shop to quickly log in.
-
-   ```bash
-   shopify-cli add yourshopname
-   ```
-
-   Follow the prompts for the shop domain, API key and password.
-
-3. Start the console for the connection.
-
-   ```bash
-   shopify-cli console
-   ```
-
-4. To see the full list of commands, type:
-
-   ```bash
-   shopify-cli help
-   ```
-
-# Contributing
-
-After checking out the source, run:
-
-  `$ bundle install && bundle exec rake test`
-
-# License:
-
-Copyright (c) 2015 Shopify
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+gem install shopify_cli -v v1.0.3
+```

--- a/bin/shopify-api
+++ b/bin/shopify-api
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../lib/shopify_api_console',__FILE__)
+require File.expand_path('../../lib/shopify_api_console/console',__FILE__)
+ShopifyAPIConsole::Console.start(ARGV)
+

--- a/bin/shopify-cli
+++ b/bin/shopify-cli
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-require File.expand_path('../../lib/shopify_cli',__FILE__)
-require File.expand_path('../../lib/shopify_cli/cli',__FILE__)
-ShopifyCLI::Cli.start(ARGV)
-

--- a/lib/shopify_api_console.rb
+++ b/lib/shopify_api_console.rb
@@ -1,0 +1,3 @@
+module ShopifyAPIConsole
+  VERSION = "2.0.0"
+end

--- a/lib/shopify_api_console/console.rb
+++ b/lib/shopify_api_console/console.rb
@@ -3,8 +3,8 @@ require 'abbrev'
 require 'yaml'
 require 'shopify_api'
 
-module ShopifyCLI
-  class Cli < Thor
+module ShopifyAPIConsole
+  class Console < Thor
     include Thor::Actions
 
     class ConfigFileError < StandardError

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -1,4 +1,0 @@
-module ShopifyCLI
-  VERSION = "1.0.3"
-  warn "[DEPRECATION] This gem has been renamed to shopify_api_console. Please switch to shopify_api_console v2+ as soon as possible."
-end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -1,3 +1,4 @@
 module ShopifyCLI
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
+  warn "[DEPRECATION] This gem has been renamed to shopify_api_console. Please switch to shopify_api_console v2+ as soon as possible."
 end

--- a/shopify_api_console.gemspec
+++ b/shopify_api_console.gemspec
@@ -1,12 +1,12 @@
 $:.push File.expand_path("../lib", __FILE__)
-require 'shopify_cli'
+require 'shopify_api_console'
 
 Gem::Specification.new do |s|
-  s.name = %q{shopify_cli}
-  s.version = ShopifyCLI::VERSION
+  s.name = %q{shopify_api_console}
+  s.version = ShopifyAPIConsole::VERSION
   s.author = "Shopify"
 
-  s.summary = %q{The Shopify CLI gem is a tool for accessing the Shopify admin REST web services from the console}
+  s.summary = %q{The Shopify Admin API Console gem is a tool for accessing the Shopify Admin API from the terminal}
   s.description = %q{}
   s.homepage = %q{https://github.com/Shopify/shopify_api_console_ruby}
 

--- a/shopify_cli.gemspec
+++ b/shopify_cli.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |s|
 
   s.summary = %q{The Shopify CLI gem is a tool for accessing the Shopify admin REST web services from the console}
   s.description = %q{}
-  s.email = %q{developers@shopify.com}
-  s.homepage = %q{http://www.shopify.com/partners/apps}
+  s.homepage = %q{https://github.com/Shopify/shopify_api_console_ruby}
 
   s.extra_rdoc_files = [
     "LICENSE",

--- a/test/console_test.rb
+++ b/test/console_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
-require 'shopify_cli/cli'
+require 'shopify_api_console/console'
 require 'fileutils'
-class CliTest < Minitest::Test
+class ConsoleTest < Minitest::Test
   HOME_DIR = File.expand_path(File.dirname(__FILE__))
   TEST_HOME = File.join(HOME_DIR, 'files', 'home')
   CONFIG_DIR = File.join(TEST_HOME, '.shopify', 'shops')
@@ -11,7 +11,7 @@ class CliTest < Minitest::Test
     force_remove(TEST_HOME)
 
     ENV['HOME'] = TEST_HOME
-    @cli = ShopifyCLI::Cli.new
+    @console = ShopifyAPIConsole::Console.new
 
     FileUtils.mkdir_p(CONFIG_DIR)
     Dir.chdir(CONFIG_DIR)
@@ -28,10 +28,10 @@ class CliTest < Minitest::Test
   test "add with blank domain" do
     standard_add_shop_prompts
     $stdin.expects(:gets).times(4).returns("", "key", "pass", "y")
-    @cli.expects(:puts).with("\nopen https://foo.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
-    @cli.expects(:puts).with("Default connection is foo")
+    @console.expects(:puts).with("\nopen https://foo.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
+    @console.expects(:puts).with("Default connection is foo")
 
-    @cli.add('foo')
+    @console.add('foo')
 
     config = YAML.load(File.read(config_file('foo')))
     assert_equal 'foo.myshopify.com', config['domain']
@@ -45,10 +45,10 @@ class CliTest < Minitest::Test
   test "add with explicit domain" do
     standard_add_shop_prompts
     $stdin.expects(:gets).times(4).returns("bar.myshopify.com", "key", "pass", "y")
-    @cli.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
-    @cli.expects(:puts).with("Default connection is foo")
+    @console.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
+    @console.expects(:puts).with("Default connection is foo")
 
-    @cli.add('foo')
+    @console.add('foo')
 
     config = YAML.load(File.read(config_file('foo')))
     assert_equal 'bar.myshopify.com', config['domain']
@@ -57,38 +57,38 @@ class CliTest < Minitest::Test
   test "add with irb as shell" do
     standard_add_shop_prompts
     $stdin.expects(:gets).times(4).returns("bar.myshopify.com", "key", "pass", "fuuuuuuu")
-    @cli.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
-    @cli.expects(:puts).with("Default connection is foo")
+    @console.expects(:puts).with("\nopen https://bar.myshopify.com/admin/apps/private in your browser to create a private app and get API credentials\n")
+    @console.expects(:puts).with("Default connection is foo")
 
-    @cli.add('foo')
+    @console.add('foo')
 
     config = YAML.load(File.read(config_file('foo')))
     assert_equal 'irb', config['shell']
   end
 
   test "list" do
-    @cli.expects(:puts).with("   bar")
-    @cli.expects(:puts).with(" * foo")
+    @console.expects(:puts).with("   bar")
+    @console.expects(:puts).with(" * foo")
 
-    @cli.list
+    @console.list
   end
 
   test "show default" do
-    @cli.expects(:puts).with("Default connection is foo")
+    @console.expects(:puts).with("Default connection is foo")
 
-    @cli.default
+    @console.default
   end
 
   test "set default" do
-    @cli.expects(:puts).with("Default connection is bar")
+    @console.expects(:puts).with("Default connection is bar")
 
-    @cli.default('bar')
+    @console.default('bar')
 
     assert_equal config_file('bar'), File.readlink(DEFAULT_SYMLINK)
   end
 
   test "remove default connection" do
-    @cli.remove('foo')
+    @console.remove('foo')
 
     assert !File.exist?(DEFAULT_SYMLINK)
     assert !File.exist?(config_file('foo'))
@@ -96,7 +96,7 @@ class CliTest < Minitest::Test
   end
 
   test "remove non-default connection" do
-    @cli.remove('bar')
+    @console.remove('bar')
 
     assert_equal 'foo.yml', File.readlink(DEFAULT_SYMLINK)
     assert File.exist?(config_file('foo'))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'mocha/setup'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-require 'shopify_cli'
+require 'shopify_api_console'
 require 'shopify_api'
 
 FakeWeb.allow_net_connect = false


### PR DESCRIPTION
This PR will rename the gem and create a new 2.0.0 version.

Warning: There will be a brief period between the time that v1.0.3 (#10) is released and this PR is released, that the info here will be confusing/wrong. Given this library’s use, I believe that’s an acceptable risk.

Steps:
1. ~Release v1.0.2 on RubyGems (old release that never went out)~
2. ~Packaging for v1.0.3 release (#10)~
3. ~Release v1.0.3 on RubyGems~
4. ~Rename repo (https://github.com/Shopify/dev-acceleration/issues/1290)~
5. Packaging for v2.0.0 release (this PR)
6. Release v2.0.0 on RubyGems
7. Update help docs (https://github.com/Shopify/help/pull/8245)