### PR TITLE
v1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_cli (1.0.3)
+    shopify_cli (1.0.4)
       activemodel (>= 4.2.2)
       activesupport (>= 4.2.2)
       pry (>= 0.9.12.6)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # This gem has been renamed
 
 * Name: shopify_cli --> shopify_api_console
-* GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console_ruby
-* RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console_ruby
+* GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console
+* RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console
 
-shopify_cli 1.x will not be supported going forward. v1.0.3 will produce a deprecation warning.
+shopify_cli 1.x will not be supported going forward. v1.0.3+ will produce a deprecation warning.
 
 Starting with v2.0, the gem has been renamed to `shopify_api_console`. We recommend switching to shopify_api_console v2.0+ as soon as possible.
 
 1.x versions will continue to exist on [RubyGems](https://rubygems.org/gems/shopify_cli) and in the [GitHub releases](https://github.com/Shopify/shopify_cli/releases). If you _must_ use one of these releases, make sure to specify a version:
 
 ```
-gem install shopify_cli -v v1.0.3
+gem install shopify_cli -v v1.0.4
 ```

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -1,4 +1,4 @@
 module ShopifyCLI
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
   warn "[DEPRECATION] This gem has been renamed to shopify_api_console. Please switch to shopify_api_console v2+ as soon as possible."
 end

--- a/shopify_cli.gemspec
+++ b/shopify_cli.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |s|
   s.version = ShopifyCLI::VERSION
   s.author = "Shopify"
 
-  s.summary = %q{The Shopify CLI gem is a tool for accessing the Shopify admin REST web services from the console}
+  s.summary = %q{Deprecated! Please use the `shopify_api_console` gem.}
   s.description = %q{}
-  s.homepage = %q{https://github.com/Shopify/shopify_api_console_ruby}
+  s.homepage = %q{https://github.com/Shopify/shopify_api_console}
 
   s.extra_rdoc_files = [
     "LICENSE",


### PR DESCRIPTION
In the 1.0.3 deprecation I messed up the name of the GitHub repo and missed the gem summary. This creates a new 1.0.4 that fixes those.

Note that the base branch here is `shopify_cli`, which has a separate shipit stack that deploys to rubygems/shopify_cli, not rubygems/shopify_api_console.