### PR TITLE
fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-[![Build Status](https://travis-ci.org/Shopify/shopify_api_console_ruby.svg?branch=master)](https://travis-ci.org/Shopify/shopify_api_console_ruby)
+[![Build Status](https://travis-ci.org/Shopify/shopify_api_console.svg?branch=master)](https://travis-ci.org/Shopify/shopify_api_console)
 
 # This gem has been renamed
 
 * Name: shopify_cli --> shopify_api_console
-* GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console_ruby
+* GitHub: https://github.com/Shopify/shopify_cli --> https://github.com/Shopify/shopify_api_console
 * RubyGems: https://rubygems.org/gems/shopify_cli --> https://rubygems.org/gems/shopify_api_console
 
-shopify_cli 1.x will not be supported going forward. v1.0.3 will produce a deprecation warning.
+shopify_cli 1.x will not be supported going forward. v1.0.3+ will produce a deprecation warning.
 
 Starting with v2.0, the gem has been renamed to `shopify_api_console`. We recommend switching to shopify_api_console v2.0+ as soon as possible.
 
 1.x versions will continue to exist on [RubyGems](https://rubygems.org/gems/shopify_cli) and in the [GitHub releases](https://github.com/Shopify/shopify_cli/releases). If you _must_ use one of these releases, make sure to specify a version:
 
 ```
-gem install shopify_cli -v v1.0.3
+gem install shopify_cli -v v1.0.4
 ```
 
 # Shopify API Console for Ruby


### PR DESCRIPTION
In the 1.0.3 deprecation I messed up the name of the GitHub repo. This fixes that in the master README (but doesn’t create a new 2.0.1 version)