### PR TITLE
Add API Versioning configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,14 +26,19 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.5)
+      rexml
     fakeweb (1.3.0)
     graphql (1.12.14)
     graphql-client (0.16.0)
-      activesupport (>= 3.0, < 6.0)
-      graphql (~> 1.6)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
+    hashdiff (1.0.1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
@@ -44,8 +49,10 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (4.0.6)
     rack (2.0.7)
     rake (10.4.2)
+    rexml (3.2.5)
     shopify_api (9.4.1)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
@@ -54,6 +61,10 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -64,6 +75,7 @@ DEPENDENCIES
   mocha (>= 0.9.8)
   rake
   shopify_api_console!
+  webmock
 
 BUNDLED WITH
    2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     fakeweb (1.3.0)
-    graphql (1.9.6)
-    graphql-client (0.14.0)
+    graphql (1.12.14)
+    graphql-client (0.16.0)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
     i18n (1.6.0)
@@ -46,7 +46,7 @@ GEM
       method_source (~> 0.9.0)
     rack (2.0.7)
     rake (10.4.2)
-    shopify_api (7.0.1)
+    shopify_api (9.4.1)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Commands:
 ```
 
 You’re presented with options for setting up and managing connection configuration. Nothing is set up yet, so start by adding a connection. Name it whatever you like, but make sure that the URL matches up with that of your development store. You’ll be prompted to enter in your API key and password. Be sure to enter the API password, not secret.
+To learn more about Shopify API release schedule to find the API version, please read [Shopify API Versioning](https://shopify.dev/api/usage/versioning)
 
 ```sh
 $ shopify-api add myshopifystore
@@ -81,6 +82,7 @@ Domain? (leave blank for myshopifystore.myshopify.com) myshopifystore.myshopify.
 open https://myshopifystore.myshopify.com/admin/apps/private in your browser to get API credentials
 API key? [REDACTED]
 Password? [REDACTED]
+API version? Leave blank for the latest version
 create  .shopify/shops/myshopifystore.yml
 remove  .shopify/shops/default
 Default connection is myshopifystore

--- a/lib/shopify_api_console/console.rb
+++ b/lib/shopify_api_console/console.rb
@@ -2,6 +2,9 @@ require 'thor'
 require 'abbrev'
 require 'yaml'
 require 'shopify_api'
+require 'net/http'
+require 'uri'
+require 'json'
 
 module ShopifyAPIConsole
   class Console < Thor
@@ -9,8 +12,6 @@ module ShopifyAPIConsole
 
     class ConfigFileError < StandardError
     end
-
-    SHOPIFY_API_RELEASE_MONTHS = [1, 4, 7, 10]
 
     desc "list", "list available connections"
     def list
@@ -34,7 +35,7 @@ module ShopifyAPIConsole
         config['api_key']  = ask("API key?")
         config['password'] = ask("Password?")
         config['api_version'] = ask("API version? Leave blank for the latest version")
-        config['api_version'] = shopify_api_latest_version if config['api_version'].blank?
+        config['api_version'] = shopify_api_latest_version(config) if config['api_version'].blank?
         if ask("Would you like to use pry as your shell? (y/n)") === "y"
           config["shell"] = "pry"
         else
@@ -186,10 +187,39 @@ module ShopifyAPIConsole
       raise ConfigFileError, "There is no config file at #{filename}"
     end
 
-    def shopify_api_latest_version
-      quarter = 3
-      latest_released_month = SHOPIFY_API_RELEASE_MONTHS[(Time.now.month - 1)/ quarter]
-      Time.new(Time.now.year, latest_released_month).strftime("%Y-%m")
+    def shopify_api_latest_version(config)
+      public_versions = query_shopify_api_versions(config)
+      if public_versions.empty?
+        puts "\nCannot automatically set the latest Shopify API version. You need to specify it manually\n"
+      else
+        public_versions.select { |version| version["supported"] }.map { |version| version["handle"] }.sort.last
+      end
+    end
+    
+    def query_shopify_api_versions(config)
+      uri = URI.parse("https://#{config['domain']}/admin/api/graphql.json")
+      request = Net::HTTP::Post.new(uri)
+      request.content_type = "application/graphql"
+      request["X-Shopify-Access-Token"] = config['password'] 
+      request.body = "
+        {
+          publicApiVersions {
+            handle
+            supported
+            displayName
+          }
+        }
+      "
+
+      req_options = {
+        use_ssl: uri.scheme == "https",
+      }
+
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+
+      response.code.to_i == 200 ? JSON.parse(response.body)["data"]["publicApiVersions"] : Array.new
     end
   end
 end

--- a/shopify_api_console.gemspec
+++ b/shopify_api_console.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   dev_dependencies = [['mocha', '>= 0.9.8'],
                       ['fakeweb'],
+                      ['webmock'],
                       ['minitest', '~> 5.0'],
                       ['rake']
   ]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
 require 'rubygems'
 require 'minitest/autorun'
 require 'fakeweb'
+require 'webmock/minitest'
 require 'mocha/setup'
+require 'json'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
# Description
Add API version configuration to ShopifyAPI

## Context
We have all setup for API key, Password, Shop domain, etc. However, Shopify API still requires us to specify the API version to make request using the correct API version. I think we should make this as a configuration to make it more convenient.

This will also help to fix this issue https://github.com/Shopify/shopify_api_console/issues/7

## Proposed Solution
The configuration for API version will either
- Use the API version specified by user input
- Automatically find the latest version to set as default if the user does not specify the input. The latest version is automatically figured out by selecting the last API version released quarterly by Shopify according to https://shopify.dev/api/usage/versioning and https://shopify.dev/api/admin/graphql/reference/common-objects/queryroot#publicapiversions-2021-07 (https://github.com/Shopify/shopify_api_console/pull/22#discussion_r689543615)

## What changes in this PR
- [x] Add prompt to ask for API version
- [x] Implement a mechanism to automatically figure out the latest API version using the current date & time
- [x] Add test to make sure the latest API version mechanism working correctly with every month in a year
- [x] Update Shopify API, GraphQL and GraphQL client gems to the latest
- [x] Update README to let people know how to configure the API version
- [x] Add `webmock` to test the HTTP Request as `fakeweb` is no longer maintained